### PR TITLE
Fix bdk version to match version in 'bdk-reserves' crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-bdk = { version = "^0.7", default-features = false, features = ["all-keys"]}
+bdk = { version = "^0.8", default-features = false, features = ["all-keys"]}
 bdk-macros = "^0.4"
 structopt = "^0.3"
 serde_json = { version = "^1.0" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,12 +130,12 @@ use bdk::keys::{DerivableKey, DescriptorKey, ExtendedKey, GeneratableKey, Genera
 use bdk::miniscript::miniscript;
 #[cfg(feature = "compiler")]
 use bdk::miniscript::policy::Concrete;
-#[cfg(feature = "reserves")]
-use bdk_reserves::reserves::{verify_proof, ProofOfReserves};
 use bdk::wallet::AddressIndex;
 use bdk::Error;
 use bdk::SignOptions;
 use bdk::{FeeRate, KeychainKind, Wallet};
+#[cfg(feature = "reserves")]
+use bdk_reserves::reserves::{verify_proof, ProofOfReserves};
 
 /// Global options
 ///
@@ -733,7 +733,7 @@ where
     D: BatchDatabase,
 {
     match offline_subcommand {
-        GetNewAddress => Ok(json!({"address": wallet.get_address(AddressIndex::New)?})),
+        GetNewAddress => Ok(json!({"address": wallet.get_address(AddressIndex::New)?.address})),
         ListUnspent => Ok(serde_json::to_value(&wallet.list_unspent()?)?),
         ListTransactions => Ok(serde_json::to_value(&wallet.list_transactions(false)?)?),
         GetBalance => Ok(json!({"satoshi": wallet.get_balance()?})),
@@ -930,7 +930,6 @@ where
                 panic!("Missing `message` option")
             };
 
-            let wallet: &ProofOfReserves = wallet;
             let mut psbt = maybe_await!(wallet.create_proof(&message))?;
 
             let _finalized = wallet.sign(
@@ -1186,10 +1185,10 @@ mod test {
     use crate::EsploraOpts;
     use crate::OfflineWalletSubCommand::{CreateTx, GetNewAddress};
     use crate::OnlineWalletSubCommand::{Broadcast, Sync};
-    #[cfg(any(feature = "compact_filters", feature = "electrum"))]
-    use crate::ProxyOpts;
     #[cfg(feature = "reserves")]
     use crate::OnlineWalletSubCommand::{ProduceProof, VerifyProof};
+    #[cfg(any(feature = "compact_filters", feature = "electrum"))]
+    use crate::ProxyOpts;
     use crate::{handle_key_subcommand, CliSubCommand, KeySubCommand, WalletSubCommand};
     #[cfg(feature = "reserves")]
     use crate::{handle_online_wallet_subcommand, handle_reserves_subcommand};
@@ -1718,12 +1717,12 @@ mod test {
                         esplora: None,
                         esplora_concurrency: 4,
                     },
-                    #[cfg(any(feature="compact_filters", feature="electrum"))]
-                    proxy_opts: ProxyOpts{
+                    #[cfg(any(feature = "compact_filters", feature = "electrum"))]
+                    proxy_opts: ProxyOpts {
                         proxy: None,
                         proxy_auth: None,
                         retries: 5,
-                    }
+                    },
                 },
                 subcommand: WalletSubCommand::OnlineWalletSubCommand(ProduceProof {
                     msg: Some(message.to_string()),
@@ -1773,12 +1772,12 @@ mod test {
                         esplora: None,
                         esplora_concurrency: 4,
                     },
-                    #[cfg(any(feature="compact_filters", feature="electrum"))]
-                    proxy_opts: ProxyOpts{
+                    #[cfg(any(feature = "compact_filters", feature = "electrum"))]
+                    proxy_opts: ProxyOpts {
                         proxy: None,
                         proxy_auth: None,
                         retries: 5,
-                    }
+                    },
                 },
                 subcommand: WalletSubCommand::OnlineWalletSubCommand(VerifyProof {
                     psbt: Some(psbt.to_string()),


### PR DESCRIPTION
### Description

Looks like the reason your trait impl wasn't found is that the `bdk` versions need to match in this crate and the corresponding `bdk-reserves` crate you're using for your new commands. 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
